### PR TITLE
Exclude main branch from linting and minify to Python 3.12

### DIFF
--- a/.github/workflows/pylint.yml
+++ b/.github/workflows/pylint.yml
@@ -2,13 +2,15 @@ name: Lint Python Code using Pylint on arbitrary push
 
 on: 
   push:
-
+    branches-ignore: 
+      - main
 jobs:
   lint:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: 
+          - "3.12"
     steps:
     - name: Check out code
       uses: actions/checkout@v4


### PR DESCRIPTION
Exclude main branch from linting and minify to Python 3.12